### PR TITLE
Default Step 구현

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -24,13 +24,13 @@ class PointController @Autowired constructor(
     }
 
     /**
-     * TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.
+     * 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.
      */
     @GetMapping("{id}/histories")
     fun history(
         @PathVariable id: Long,
     ): List<PointHistory> {
-        return emptyList()
+        return pointService.getUserPointHistory(id)
     }
 
     /**

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -1,5 +1,7 @@
 package io.hhplus.tdd.point
 
+import io.hhplus.tdd.point.dto.response.PointHistoryResponse
+import io.hhplus.tdd.point.dto.response.UserPointResponse
 import io.hhplus.tdd.service.PointService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -19,7 +21,7 @@ class PointController @Autowired constructor(
     @GetMapping("{id}")
     fun point(
         @PathVariable id: Long,
-    ): UserPoint {
+    ): UserPointResponse {
         return pointService.getUserPoint(id)
     }
 
@@ -29,7 +31,7 @@ class PointController @Autowired constructor(
     @GetMapping("{id}/histories")
     fun history(
         @PathVariable id: Long,
-    ): List<PointHistory> {
+    ): List<PointHistoryResponse> {
         return pointService.getUserPointHistory(id)
     }
 
@@ -40,7 +42,7 @@ class PointController @Autowired constructor(
     fun charge(
         @PathVariable id: Long,
         @RequestBody amount: Long,
-    ): UserPoint {
+    ): UserPointResponse {
         return pointService.chargeUserPoint(id, amount)
     }
 
@@ -51,7 +53,7 @@ class PointController @Autowired constructor(
     fun use(
         @PathVariable id: Long,
         @RequestBody amount: Long,
-    ): UserPoint {
+    ): UserPointResponse {
         return pointService.useUserPoint(id, amount)
     }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -45,13 +45,13 @@ class PointController @Autowired constructor(
     }
 
     /**
-     * TODO - 특정 유저의 포인트를 사용하는 기능을 작성해주세요.
+     * 특정 유저의 포인트를 사용하는 기능을 작성해주세요.
      */
     @PatchMapping("{id}/use")
     fun use(
         @PathVariable id: Long,
         @RequestBody amount: Long,
     ): UserPoint {
-        return UserPoint(0, 0, 0)
+        return pointService.useUserPoint(id, amount)
     }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -14,13 +14,13 @@ class PointController @Autowired constructor(
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     /**
-     * TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
+     *  특정 유저의 포인트를 조회하는 기능을 작성해주세요.
      */
     @GetMapping("{id}")
     fun point(
         @PathVariable id: Long,
     ): UserPoint {
-        return UserPoint(0, 0, 0)
+        return pointService.getUserPoint(id)
     }
 
     /**

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -1,12 +1,16 @@
 package io.hhplus.tdd.point
 
+import io.hhplus.tdd.service.PointService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/point")
-class PointController {
+class PointController @Autowired constructor(
+    private val pointService: PointService
+){
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     /**
@@ -30,14 +34,14 @@ class PointController {
     }
 
     /**
-     * TODO - 특정 유저의 포인트를 충전하는 기능을 작성해주세요.
+     * 특정 유저의 포인트를 충전하는 기능을 작성해주세요.
      */
     @PatchMapping("{id}/charge")
     fun charge(
         @PathVariable id: Long,
         @RequestBody amount: Long,
     ): UserPoint {
-        return UserPoint(0, 0, 0)
+        return pointService.chargeUserPoint(id, amount)
     }
 
     /**

--- a/src/main/kotlin/io/hhplus/tdd/point/PointHistory.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointHistory.kt
@@ -6,7 +6,29 @@ data class PointHistory(
     val type: TransactionType,
     val amount: Long,
     val timeMillis: Long,
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as PointHistory
+
+        if (id != other.id) return false
+        if (userId != other.userId) return false
+        if (type != other.type) return false
+        if (amount != other.amount) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + userId.hashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + amount.hashCode()
+        return result
+    }
+}
 
 /**
  * 포인트 트랜잭션 종류

--- a/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
@@ -1,7 +1,33 @@
 package io.hhplus.tdd.point
 
-data class UserPoint(
-    val id: Long,
-    val point: Long,
-    val updateMillis: Long,
-)
+class UserPoint(
+    private val id: Long,
+    private var point: Long,
+    private val updateMillis: Long,
+) {
+
+    val currentPoint: Long
+        get() = point
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as UserPoint
+
+        if (id != other.id) return false
+        if (point != other.point) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + point.hashCode()
+        return result
+    }
+
+    fun chargePoint(point: Long) {
+        this.point += point
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
@@ -30,4 +30,9 @@ class UserPoint(
     fun chargePoint(point: Long) {
         this.point += point
     }
+
+    fun usePoint(point: Long) {
+        if(this.point < point) throw RuntimeException("잔여 포인트가 부족합니다")
+        this.point -= point
+    }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
@@ -1,13 +1,10 @@
 package io.hhplus.tdd.point
 
-class UserPoint(
-    private val id: Long,
-    private var point: Long,
-    private val updateMillis: Long,
+data class UserPoint(
+    val id: Long,
+    var point: Long,
+    val updateMillis: Long,
 ) {
-
-    val currentPoint: Long
-        get() = point
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/io/hhplus/tdd/point/dto/response/PointHistoryResponse.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/dto/response/PointHistoryResponse.kt
@@ -1,0 +1,26 @@
+package io.hhplus.tdd.point.dto.response
+
+import io.hhplus.tdd.point.PointHistory
+import io.hhplus.tdd.point.TransactionType
+
+data class PointHistoryResponse(
+    val id: Long,
+    val userId: Long,
+    val type: TransactionType,
+    val amount: Long,
+    val timeMillis: Long,
+) {
+    companion object {
+        fun of(
+            pointHistory: PointHistory
+        ): PointHistoryResponse {
+            return PointHistoryResponse(
+                id = pointHistory.id,
+                userId = pointHistory.userId,
+                type = pointHistory.type,
+                amount = pointHistory.amount,
+                timeMillis = pointHistory.timeMillis,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/dto/response/UserPointResponse.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/dto/response/UserPointResponse.kt
@@ -1,0 +1,21 @@
+package io.hhplus.tdd.point.dto.response
+
+import io.hhplus.tdd.point.UserPoint
+
+data class UserPointResponse(
+    val id: Long,
+    var point: Long,
+    val updateMillis: Long,
+){
+    companion object {
+        fun of(
+            userPoint: UserPoint
+        ): UserPointResponse {
+            return UserPointResponse(
+                id = userPoint.id,
+                point = userPoint.point,
+                updateMillis = userPoint.updateMillis
+            )
+        }
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/service/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/service/PointService.kt
@@ -46,4 +46,10 @@ class PointService @Autowired constructor(
     ): List<PointHistory> {
         return pointHistoryTable.selectAllByUserId(userId)
     }
+
+    fun getUserPoint(
+        userId: Long
+    ): UserPoint {
+        return userPointTable.selectById(userId)
+    }
 }

--- a/src/main/kotlin/io/hhplus/tdd/service/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/service/PointService.kt
@@ -5,6 +5,8 @@ import io.hhplus.tdd.database.UserPointTable
 import io.hhplus.tdd.point.PointHistory
 import io.hhplus.tdd.point.TransactionType
 import io.hhplus.tdd.point.UserPoint
+import io.hhplus.tdd.point.dto.response.PointHistoryResponse
+import io.hhplus.tdd.point.dto.response.UserPointResponse
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
@@ -16,7 +18,7 @@ class PointService @Autowired constructor(
 
     fun chargeUserPoint(
         userId: Long, amount: Long
-    ) : UserPoint {
+    ) : UserPointResponse {
 
         val userPoint = userPointTable.selectById(userId)
         userPoint.chargePoint(amount)
@@ -25,12 +27,12 @@ class PointService @Autowired constructor(
 
         pointHistoryTable.insert(userId, amount, TransactionType.CHARGE, chargedPoint.updateMillis)
 
-        return chargedPoint
+        return UserPointResponse.of(chargedPoint)
     }
 
     fun useUserPoint(
         userId: Long, amount: Long
-    ): UserPoint {
+    ): UserPointResponse {
         val userPoint = userPointTable.selectById(userId)
         userPoint.usePoint(amount)
 
@@ -38,18 +40,19 @@ class PointService @Autowired constructor(
 
         pointHistoryTable.insert(userId, amount, TransactionType.USE, usedPoint.updateMillis)
 
-        return usedPoint
+        return UserPointResponse.of(usedPoint)
     }
 
     fun getUserPointHistory(
         userId: Long
-    ): List<PointHistory> {
+    ): List<PointHistoryResponse> {
         return pointHistoryTable.selectAllByUserId(userId)
+            .map { PointHistoryResponse.of(it) }
     }
 
     fun getUserPoint(
         userId: Long
-    ): UserPoint {
-        return userPointTable.selectById(userId)
+    ): UserPointResponse {
+        return UserPointResponse.of(userPointTable.selectById(userId))
     }
 }

--- a/src/main/kotlin/io/hhplus/tdd/service/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/service/PointService.kt
@@ -1,0 +1,25 @@
+package io.hhplus.tdd.service
+
+import io.hhplus.tdd.database.PointHistoryTable
+import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.point.PointHistory
+import io.hhplus.tdd.point.UserPoint
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class PointService @Autowired constructor(
+    private val pointHistoryTable: PointHistoryTable,
+    private val userPointTable: UserPointTable
+){
+
+    fun chargeUserPoint(
+        userId: Long, amount: Long
+    ) : UserPoint {
+
+        val userPoint = userPointTable.selectById(userId)
+        userPoint.chargePoint(amount)
+
+        return userPointTable.insertOrUpdate(userId, userPoint.currentPoint)
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/service/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/service/PointService.kt
@@ -3,6 +3,7 @@ package io.hhplus.tdd.service
 import io.hhplus.tdd.database.PointHistoryTable
 import io.hhplus.tdd.database.UserPointTable
 import io.hhplus.tdd.point.PointHistory
+import io.hhplus.tdd.point.TransactionType
 import io.hhplus.tdd.point.UserPoint
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
@@ -20,7 +21,11 @@ class PointService @Autowired constructor(
         val userPoint = userPointTable.selectById(userId)
         userPoint.chargePoint(amount)
 
-        return userPointTable.insertOrUpdate(userId, userPoint.currentPoint)
+        val chargedPoint = userPointTable.insertOrUpdate(userId, userPoint.point)
+
+        pointHistoryTable.insert(userId, amount, TransactionType.CHARGE, chargedPoint.updateMillis)
+
+        return chargedPoint
     }
 
     fun useUserPoint(
@@ -29,6 +34,16 @@ class PointService @Autowired constructor(
         val userPoint = userPointTable.selectById(userId)
         userPoint.usePoint(amount)
 
-        return userPointTable.insertOrUpdate(userId, userPoint.currentPoint)
+        val usedPoint = userPointTable.insertOrUpdate(userId, userPoint.point)
+
+        pointHistoryTable.insert(userId, amount, TransactionType.USE, usedPoint.updateMillis)
+
+        return usedPoint
+    }
+
+    fun getUserPointHistory(
+        userId: Long
+    ): List<PointHistory> {
+        return pointHistoryTable.selectAllByUserId(userId)
     }
 }

--- a/src/main/kotlin/io/hhplus/tdd/service/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/service/PointService.kt
@@ -22,4 +22,13 @@ class PointService @Autowired constructor(
 
         return userPointTable.insertOrUpdate(userId, userPoint.currentPoint)
     }
+
+    fun useUserPoint(
+        userId: Long, amount: Long
+    ): UserPoint {
+        val userPoint = userPointTable.selectById(userId)
+        userPoint.usePoint(amount)
+
+        return userPointTable.insertOrUpdate(userId, userPoint.currentPoint)
+    }
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
@@ -2,6 +2,7 @@ package io.hhplus.tdd.point
 
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -20,5 +21,31 @@ class UserPointTest {
 
         //then
         assertThat(userPoint.currentPoint).isEqualTo(40)
+    }
+
+    @Test
+    @DisplayName("포인트를 사용한다")
+    fun testUsePoint() {
+        //given
+        val userId = 10L
+        val userPoint = UserPoint(userId, 10, 0)
+
+        //when
+        userPoint.usePoint(5)
+
+        //then
+        assertThat(userPoint.currentPoint).isEqualTo(5)
+    }
+
+    @Test
+    @DisplayName("포인트를 사용한다시 잔액이 부족하면 오류가 발생한다")
+    fun testUsePointWithLessPoint() {
+        //given
+        val userId = 10L
+        val userPoint = UserPoint(userId, 10, 0)
+
+        //when then
+        assertThatThrownBy { userPoint.usePoint(15) }
+            .isInstanceOf(RuntimeException::class.java)
     }
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
@@ -20,7 +20,7 @@ class UserPointTest {
         userPoint.chargePoint(30)
 
         //then
-        assertThat(userPoint.currentPoint).isEqualTo(40)
+        assertThat(userPoint.point).isEqualTo(40)
     }
 
     @Test
@@ -34,7 +34,7 @@ class UserPointTest {
         userPoint.usePoint(5)
 
         //then
-        assertThat(userPoint.currentPoint).isEqualTo(5)
+        assertThat(userPoint.point).isEqualTo(5)
     }
 
     @Test

--- a/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
@@ -1,0 +1,24 @@
+package io.hhplus.tdd.point
+
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class UserPointTest {
+
+    @Test
+    @DisplayName("포인트를 충전한다")
+    fun testChargePoint() {
+        //given
+        val userId = 10L
+        val userPoint = UserPoint(userId, 10, 0)
+
+        //when
+        userPoint.chargePoint(30)
+
+        //then
+        assertThat(userPoint.currentPoint).isEqualTo(40)
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/service/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/service/PointServiceTest.kt
@@ -2,19 +2,15 @@ package io.hhplus.tdd.service
 
 import io.hhplus.tdd.database.PointHistoryTable
 import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.point.PointHistory
+import io.hhplus.tdd.point.TransactionType
 import io.hhplus.tdd.point.UserPoint
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
-import org.mockito.Mockito.`when`
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 
 @SpringBootTest
 class PointServiceTest {
@@ -84,4 +80,37 @@ class PointServiceTest {
             .hasMessage("잔여 포인트가 부족합니다")
 
     }
+
+    @Test
+    @DisplayName("유저 포인트 충전시 HistoryTable 에 저장된다")
+    fun historyTableUseTest() {
+        //given
+        val userId: Long = 10L;
+        pointService.chargeUserPoint(userId, 10L)
+        pointService.chargeUserPoint(userId, 20L)
+
+        //when
+        val histories = pointService.getUserPointHistory(userId)
+
+        assertThat(histories).hasSize(2)
+        assertThat(histories.get(0)).isEqualTo(PointHistory(1, userId, TransactionType.CHARGE, 10, 0))
+        assertThat(histories.get(1)).isEqualTo(PointHistory(2, userId, TransactionType.CHARGE, 20, 0))
+    }
+
+    @Test
+    @DisplayName("유저 포인트 사용시 HistoryTable 에 저장된다")
+    fun historyTableChargeTest() {
+        //given
+        val userId: Long = 10L;
+        pointService.chargeUserPoint(userId, 100L)
+        pointService.useUserPoint(userId, 20L)
+
+        //when
+        val histories = pointService.getUserPointHistory(userId)
+
+        assertThat(histories).hasSize(2)
+        assertThat(histories.get(0)).isEqualTo(PointHistory(1, userId, TransactionType.CHARGE, 100, 0))
+        assertThat(histories.get(1)).isEqualTo(PointHistory(2, userId, TransactionType.USE, 20, 0))
+    }
+
 }

--- a/src/test/kotlin/io/hhplus/tdd/service/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/service/PointServiceTest.kt
@@ -5,25 +5,31 @@ import io.hhplus.tdd.database.UserPointTable
 import io.hhplus.tdd.point.UserPoint
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 
 @SpringBootTest
-class PointServiceTest @Autowired constructor(
-    private val pointService: PointService,
-    private val pointHistoryTable: PointHistoryTable,
-    private val userPointTable: UserPointTable
-) {
+class PointServiceTest {
 
-    /**
-     * memo: UserPoint 에 대한 검증을 equals 를 통해 하고싶음.
-     * 이때 updateMills 까지 비교해야할까?
-     * 인데 안하기로함. 수정할 수 없는 UserPointTable 에서 insert 하는 시점에 updateMills 를 지정하기때문
-     * 내가 직접 제어가 안됨
-     */
+    private lateinit var userPointTable: UserPointTable
+    private lateinit var pointHistoryTable: PointHistoryTable
+    private lateinit var pointService: PointService
+
+    @BeforeEach
+    fun setUp() {
+        userPointTable = UserPointTable()
+        pointHistoryTable = PointHistoryTable()
+        pointService = PointService(pointHistoryTable, userPointTable)
+    }
+
     @Test
     @DisplayName("포인트를 충전한다")
     fun chargePoint() {
@@ -49,5 +55,33 @@ class PointServiceTest @Autowired constructor(
 
         //then
         assertThat(chargedPoint).isEqualTo(UserPoint(userId, 100L, 0L))
+    }
+
+    @Test
+    @DisplayName("유저 포인트를 사용한다")
+    fun usePoint() {
+        //given
+        val userId: Long = 10L;
+        val initPoint = userPointTable.insertOrUpdate(userId, 10L)
+
+        //when
+        val usedPoint = pointService.useUserPoint(userId, 5L)
+
+        //then
+        assertThat(usedPoint).isEqualTo(UserPoint(userId, 5L, 0L))
+    }
+
+    @Test
+    @DisplayName("유저 포인트 사용시 잔액이 부족하면 오류가 발생한다")
+    fun usePointWithLessPoint() {
+        //given
+        val userId: Long = 10L;
+        val initPoint = userPointTable.insertOrUpdate(userId, 10L)
+
+        //when then
+        assertThatThrownBy { pointService.useUserPoint(userId, 20L) }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessage("잔여 포인트가 부족합니다")
+
     }
 }

--- a/src/test/kotlin/io/hhplus/tdd/service/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/service/PointServiceTest.kt
@@ -37,7 +37,7 @@ class PointServiceTest {
         val chargedPoint = pointService.chargeUserPoint(userId, 100L);
 
         //then
-        assertThat(chargedPoint).isEqualTo(UserPoint(userId, 110L, 0L))
+        assertThat(chargedPoint.point).isEqualTo(110L)
     }
 
     @Test
@@ -50,7 +50,7 @@ class PointServiceTest {
         val chargedPoint = pointService.chargeUserPoint(userId, 100L);
 
         //then
-        assertThat(chargedPoint).isEqualTo(UserPoint(userId, 100L, 0L))
+        assertThat(chargedPoint.point).isEqualTo(100L)
     }
 
     @Test
@@ -64,7 +64,7 @@ class PointServiceTest {
         val usedPoint = pointService.useUserPoint(userId, 5L)
 
         //then
-        assertThat(usedPoint).isEqualTo(UserPoint(userId, 5L, 0L))
+        assertThat(usedPoint.point).isEqualTo(5L)
     }
 
     @Test
@@ -93,8 +93,14 @@ class PointServiceTest {
         val histories = pointService.getUserPointHistory(userId)
 
         assertThat(histories).hasSize(2)
-        assertThat(histories.get(0)).isEqualTo(PointHistory(1, userId, TransactionType.CHARGE, 10, 0))
-        assertThat(histories.get(1)).isEqualTo(PointHistory(2, userId, TransactionType.CHARGE, 20, 0))
+        assertThat(histories.get(0).id).isEqualTo(1)
+        assertThat(histories.get(0).amount).isEqualTo(10)
+        assertThat(histories.get(0).type).isEqualTo(TransactionType.CHARGE)
+        assertThat(histories.get(0).userId).isEqualTo(userId)
+        assertThat(histories.get(1).id).isEqualTo(2)
+        assertThat(histories.get(1).amount).isEqualTo(20)
+        assertThat(histories.get(1).type).isEqualTo(TransactionType.CHARGE)
+        assertThat(histories.get(1).userId).isEqualTo(userId)
     }
 
     @Test
@@ -109,8 +115,14 @@ class PointServiceTest {
         val histories = pointService.getUserPointHistory(userId)
 
         assertThat(histories).hasSize(2)
-        assertThat(histories.get(0)).isEqualTo(PointHistory(1, userId, TransactionType.CHARGE, 100, 0))
-        assertThat(histories.get(1)).isEqualTo(PointHistory(2, userId, TransactionType.USE, 20, 0))
+        assertThat(histories.get(0).id).isEqualTo(1)
+        assertThat(histories.get(0).amount).isEqualTo(100)
+        assertThat(histories.get(0).type).isEqualTo(TransactionType.CHARGE)
+        assertThat(histories.get(0).userId).isEqualTo(userId)
+        assertThat(histories.get(1).id).isEqualTo(2)
+        assertThat(histories.get(1).amount).isEqualTo(20)
+        assertThat(histories.get(1).type).isEqualTo(TransactionType.USE)
+        assertThat(histories.get(1).userId).isEqualTo(userId)
     }
 
     @Test
@@ -124,7 +136,8 @@ class PointServiceTest {
         val userPoint = pointService.getUserPoint(userId)
 
         //then
-        assertThat(userPoint).isEqualTo(initPoint)
+        assertThat(userPoint.point).isEqualTo(10)
+        assertThat(userPoint.id).isEqualTo(userId)
     }
 
     @Test
@@ -137,7 +150,8 @@ class PointServiceTest {
         val userPoint = pointService.getUserPoint(userId)
 
         //then
-        assertThat(userPoint).isEqualTo(UserPoint(userId, 0L, 0L))
+        assertThat(userPoint.point).isEqualTo(0)
+        assertThat(userPoint.id).isEqualTo(userId)
     }
 
     @Test
@@ -152,7 +166,7 @@ class PointServiceTest {
         val userPoint = pointService.getUserPoint(userId)
 
         //then
-        assertThat(userPoint).isEqualTo(UserPoint(userId, 110L, 0L))
+        assertThat(userPoint.point).isEqualTo(110)
     }
 
     @Test
@@ -167,6 +181,6 @@ class PointServiceTest {
         val userPoint = pointService.getUserPoint(userId)
 
         //then
-        assertThat(userPoint).isEqualTo(UserPoint(userId, 70L, 0L))
+        assertThat(userPoint.point).isEqualTo(70)
     }
 }

--- a/src/test/kotlin/io/hhplus/tdd/service/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/service/PointServiceTest.kt
@@ -113,4 +113,60 @@ class PointServiceTest {
         assertThat(histories.get(1)).isEqualTo(PointHistory(2, userId, TransactionType.USE, 20, 0))
     }
 
+    @Test
+    @DisplayName("유저 포인트를 조회한다")
+    fun getUserPoint() {
+        //given
+        val userId: Long = 10L;
+        val initPoint = userPointTable.insertOrUpdate(userId, 10L)
+
+        //when
+        val userPoint = pointService.getUserPoint(userId)
+
+        //then
+        assertThat(userPoint).isEqualTo(initPoint)
+    }
+
+    @Test
+    @DisplayName("유저 포인트를 조회한다. 없다면 기본값은 0 이다")
+    fun getUserPointWithoutInitData() {
+        //given
+        val userId: Long = 10L;
+
+        //when
+        val userPoint = pointService.getUserPoint(userId)
+
+        //then
+        assertThat(userPoint).isEqualTo(UserPoint(userId, 0L, 0L))
+    }
+
+    @Test
+    @DisplayName("유저 포인트를 충전하면 충전된 포인트가 조회된다")
+    fun getUserPointWithCharge() {
+        //given
+        val userId: Long = 10L;
+        val initPoint = userPointTable.insertOrUpdate(userId, 10L)
+        val chargedPoint = pointService.chargeUserPoint(userId, 100L)
+
+        //when
+        val userPoint = pointService.getUserPoint(userId)
+
+        //then
+        assertThat(userPoint).isEqualTo(UserPoint(userId, 110L, 0L))
+    }
+
+    @Test
+    @DisplayName("유저 포인트를 사용하면 사용된 포인트가 조회된다")
+    fun getUserPointWithUse() {
+        //given
+        val userId: Long = 10L;
+        val initPoint = userPointTable.insertOrUpdate(userId, 100L)
+        val usedPoint = pointService.useUserPoint(userId, 30L)
+
+        //when
+        val userPoint = pointService.getUserPoint(userId)
+
+        //then
+        assertThat(userPoint).isEqualTo(UserPoint(userId, 70L, 0L))
+    }
 }

--- a/src/test/kotlin/io/hhplus/tdd/service/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/service/PointServiceTest.kt
@@ -1,0 +1,53 @@
+package io.hhplus.tdd.service
+
+import io.hhplus.tdd.database.PointHistoryTable
+import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.point.UserPoint
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class PointServiceTest @Autowired constructor(
+    private val pointService: PointService,
+    private val pointHistoryTable: PointHistoryTable,
+    private val userPointTable: UserPointTable
+) {
+
+    /**
+     * memo: UserPoint 에 대한 검증을 equals 를 통해 하고싶음.
+     * 이때 updateMills 까지 비교해야할까?
+     * 인데 안하기로함. 수정할 수 없는 UserPointTable 에서 insert 하는 시점에 updateMills 를 지정하기때문
+     * 내가 직접 제어가 안됨
+     */
+    @Test
+    @DisplayName("포인트를 충전한다")
+    fun chargePoint() {
+        //given
+        val userId: Long = 10L;
+        val initPoint = userPointTable.insertOrUpdate(userId, 10L)
+
+        //when
+        val chargedPoint = pointService.chargeUserPoint(userId, 100L);
+
+        //then
+        assertThat(chargedPoint).isEqualTo(UserPoint(userId, 110L, 0L))
+    }
+
+    @Test
+    @DisplayName("기존에 저장된 유저 포인트가 없다면 0점으로 시작한다")
+    fun chargePointWithoutInitData() {
+        //given
+        val userId: Long = 10L;
+
+        //when
+        val chargedPoint = pointService.chargeUserPoint(userId, 100L);
+
+        //then
+        assertThat(chargedPoint).isEqualTo(UserPoint(userId, 100L, 0L))
+    }
+}


### PR DESCRIPTION
# 변경사항
- PointService 추가
  - 포인트 충전 
  - 포인트 사용 
  - 포인트 조회 
  - 포인트 사용 내역 조회 
- UserPoint 변경
  - 불변이던 point 를 가변으로 변경하여 충전과 사용에대한 처리를 UserPoint에서 진행
- Response 객체 생성
  - Controller 에서 반환할때 Response 형식으로 변환하여 응답

# 리뷰포인트
- UserPoint 의 point를 가변으로 설정한 이유
  -  포인트 사용이나 충전에 대한 처리, 검증을 UserPoint 내부에서 하고싶었습니다.
  - 문제는 수정 불가능한 저장 로직이 id와 amount를 별도로 입력받아서 새로운 UserPoint를 반환해주기에 이 필드의 변경이 크게 의미있는지 잘 모르겠습니다.
    - 만약 저장로직을 수정할 수 있다면, UserPoint 를 파라미터로 받아 저장하도록 변경하면 더 좋지 않을까 생각합니다! 

# 기타
- UserPoint와 PointHistory에 equals와 hashCode를 override 해놓은 이유
  -  처음 생각은 테스트코드에서 값에 대한 검증을할때, userPoint.point 에 직접 접근해서 검증하는게 아닌 equls를 통해 같은 객체인지 검증하고자했습니다. 문제는 updateMills가 저장로직 내부에서 정의되기에 제어가 안되는 값이라 비교가 어려웠습니다. 
  - 업데이트된 시간은 객체를 비교하는데 의미있는 값일수도 있지만 생각하기에 따라서는 없을수도 있기에..? (예를들어, 실제 객체를 비교할때 PK값은 비교하지만 createdAt 값은 비교 안하는것처럼) 이 시간 정보를 제외하고 equals와 hashCode를 override 했습니다.
  - 하지만 Service에서 반환하는 값이 Response객체로 변경됨에따라 테스트코드에서도 Entity에대한 값을 검증하는것이 아닌 Response에대해 검증을하며 현재 이 equals와 hashCode는 사용되고있진 않습니다.
  - 굳이 남겨둔 이유는, 테스트 검증할때 이런 equals를 사용하는 방식, 시간값이 내부에서 정의되어 테스트코드에서 처리할 수 없었는 내용등을 나중에 멘토님에게 질문드리고싶어서입니다 